### PR TITLE
Fix get book by

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+__pycache__
+
+.venv

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+
+            - name: Set up Docker
+              uses: docker/setup-buildx-action@v2
+
+            - name: Login into render
+              run: |
+                echo "${{ secrets.RENDER_API_KEY }}" | docker login -u _ --password-stdin registry.render.com
+
+            - name: Build and push Docker image to Render
+              run: |
+                docker build -t registry.render.com/${{ secrets.RENDER_SERVICE_ID }}/my-app:latest .
+                docker push registry.render.com/${{ secrets.RENDER_SERVICE_ID }}/my-app:latest
+  
+            - name: Deploy to Render
+              run: |
+                curl -X POST \
+                  -H "Authorization: Bearer ${{ secrets.RENDER_API_KEY }}" \
+                  -H "Accept: application/json" \
+                  -H "Content-Type: application/json" \
+                  -d '{
+                        "serviceId": "${{ secrets.RENDER_SERVICE_ID }}",
+                        "image": "registry.render.com/${{ secrets.RENDER_SERVICE_ID }}/my-app:latest"
+                      }' \
+                  https://api.render.com/v1/services/${{ secrets.RENDER_SERVICE_ID }}/deploys

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,15 +23,8 @@ jobs:
               run: |
                 docker build -t registry.render.com/${{ secrets.RENDER_SERVICE_ID }}/my-app:latest .
                 docker push registry.render.com/${{ secrets.RENDER_SERVICE_ID }}/my-app:latest
-  
-            - name: Deploy to Render
+                  - name: Trigger Render Deploy
+            
+            - name: Deploy to render on change to main
               run: |
-                curl -X POST \
-                  -H "Authorization: Bearer ${{ secrets.RENDER_API_KEY }}" \
-                  -H "Accept: application/json" \
-                  -H "Content-Type: application/json" \
-                  -d '{
-                        "serviceId": "${{ secrets.RENDER_SERVICE_ID }}",
-                        "image": "registry.render.com/${{ secrets.RENDER_SERVICE_ID }}/my-app:latest"
-                      }' \
-                  https://api.render.com/v1/services/${{ secrets.RENDER_SERVICE_ID }}/deploys
+                curl -X POST ${{ secrets.RENDER_DEPLOY_HOOK }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test
+name: Run Python Tests
 
 on:
   pull_request:
@@ -6,13 +6,31 @@ on:
       - main
 
 jobs:
-    test:
-        runs-on: ubuntu-latest
-        container:
-            image: python:3.12
-        steps:
-            - uses: actions/checkout@v3
-            - name: Install dependencies
-              run: pip install -r requirements.txt
-            - name: Run tests
-              run: pytest
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: python:3.12
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Fast API
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+            path: ~/.cache/pip
+            key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+            restore-keys: |
+              ${{ runner.os }}-pip-
+
+      - name: Run tests with pytest
+        run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        container:
+            image: python:3.12
+        steps:
+            - uses: actions/checkout@v3
+            - name: Install dependencies
+              run: pip install -r requirements.txt
+            - name: Run tests
+              run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
           pip install -r requirements.txt
-          
+
       - name: Cache pip dependencies
         uses: actions/cache@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ __pycache__/
 
 # C extensions
 *.so
-
+.ruff/
 # Distribution / packaging
 .Python
 build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt /app
+
+RUN pip install -r requirements.txt
+
+COPY . /app
+
+CMD ["python", "app.py"]

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -1,6 +1,6 @@
 from typing import OrderedDict
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, HTTPException, status
 from fastapi.responses import JSONResponse
 
 from api.db.schemas import Book, Genre, InMemoryDB

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -36,16 +36,22 @@ db.books = {
 @router.post("/", status_code=status.HTTP_201_CREATED)
 async def create_book(book: Book):
     db.add_book(book)
-    return JSONResponse(
-        status_code=status.HTTP_201_CREATED, content=book.model_dump()
-    )
+    return JSONResponse(status_code=status.HTTP_201_CREATED, content=book.model_dump())
 
 
-@router.get(
-    "/", response_model=OrderedDict[int, Book], status_code=status.HTTP_200_OK
-)
+@router.get("/", response_model=OrderedDict[int, Book], status_code=status.HTTP_200_OK)
 async def get_books() -> OrderedDict[int, Book]:
     return db.get_books()
+
+
+@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+async def get_book_by_id(book_id: int):
+    book = db.get_book(book_id)
+    if book is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Book not found"
+        )
+    return book
 
 
 @router.put("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  web:
+    build: .
+    container_name: fastapi
+    command: sh -c "uvicorn main:app --host 0.0.0.0 --port 8000 --reload"
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/app
+    working_dir: /app
+    networks:
+      - fastapi-network
+
+  nginx:
+    image: nginx:alpine
+    container_name: nginx
+    ports:
+      - "8080:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - web
+    networks:
+      - fastapi-network
+
+networks:
+  fastapi-network:
+    driver: bridge

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,23 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    server {
+        listen 80;
+        server_name localhost;
+        location / {
+            root /usr/share/nginx/html;
+            index index.html index.htm;
+        }
+
+        
+        location /api {
+            proxy_pass http://web:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for running Python tests and adds a new endpoint to the `books` API. The most important changes include the creation of a CI workflow and the addition of a new route for fetching a book by its ID.

### CI/CD Improvements:
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R1-R36): Added a new GitHub Actions workflow to run Python tests on pull requests targeting the `main` branch. This workflow sets up a Python 3.12 environment, installs dependencies, caches pip dependencies, and runs tests using pytest.

### API Enhancements:
* [`api/routes/books.py`](diffhunk://#diff-b498d5fa55d94d68c11fae6ee60120c2a5d6134276ddbe267b497926ceaea25eL39-R56): Added a new `GET` endpoint to fetch a book by its ID. The endpoint returns a 404 error if the book is not found.