### PR TITLE
feat: enhance deployment workflow and add test endpoint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: deploy
+name: Deploy
 
 on:
   push:
@@ -22,14 +22,22 @@ jobs:
       - name: Deploy to VPS
         run: |
           ssh ${{ secrets.VPS_USER }}@${{ secrets.VPS_IP }} << 'EOF'
-            cd ~/ || exit 1
+            set -e  # Exit if any command fails
+            cd /home/${{ secrets.VPS_USER }} || exit 1
+
+            # Clone or Pull Latest Code
             if [ -d "hng12-fastapi-book-project" ]; then
               cd hng12-fastapi-book-project
+              git reset --hard  # Ensure clean state
               git pull origin main
             else
               git clone https://github.com/wathika-eng/hng12-fastapi-book-project && cd hng12-fastapi-book-project
             fi
-            docker-compose down
-            docker-compose up --build -d
+
+            # Rebuild and Restart Docker Containers
+            docker compose down
+            docker compose up --build -d
+
+            # Clean Up Unused Resources
             docker system prune -af
           EOF

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -60,6 +60,11 @@ async def get_book_by_id(book_id: str = Path(..., description="ID of the book"))
     return book
 
 
+@router.get("/testing", status_code=status.HTTP_200_OK)
+async def test():
+    return JSONResponse(status_code=status.HTTP_200_OK, content={"message": "Test"})
+
+
 @router.put("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
 async def update_book(book_id: int, book: Book) -> Book:
     return JSONResponse(


### PR DESCRIPTION
This pull request includes several important changes to the deployment workflow and the API routes. The most significant updates involve improving the deployment script to ensure a clean state and adding a new testing endpoint to the API.

### Deployment Workflow Improvements:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L25-R41): Added `set -e` to exit if any command fails and updated the directory path to use `/home/${{ secrets.VPS_USER }}`.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L25-R41): Added `git reset --hard` to ensure a clean state before pulling the latest code.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L25-R41): Updated Docker commands to use `docker compose` instead of `docker-compose` and added a clean-up step for unused resources.

### API Enhancements:

* [`api/routes/books.py`](diffhunk://#diff-b498d5fa55d94d68c11fae6ee60120c2a5d6134276ddbe267b497926ceaea25eR63-R67): Added a new endpoint `/testing` that returns a JSON response with a message "Test" and status code 200.